### PR TITLE
Update .fingerprint file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3492,7 +3492,7 @@ whether corruption may be an issue (but it certainly isn't guaranteed).
 SSH into your device and run the following:
 
 ```shell
-root@dee2945:/# grep -v "/var/cache/ldconfig/aux-cache" /resinos.fingerprint | md5sum --quiet -c -
+root@dee2945:/# grep -v "/var/cache/ldconfig/aux-cache" /balenaos.fingerprint | md5sum --quiet -c -
 root@dee2945:/#
 ```
 


### PR DESCRIPTION
component: Debugging masterclass `11.2 Storage Media Corruption` example uses an outdated name for the `/<name>.fingerprint` file. Updated it from `resinos.fingerprint` to `balenaos.fingerprint`.

Change-type: patch
Signed-off-by: Genadi Naydenov <genadi@balena.io>